### PR TITLE
chore: update the type of component to library

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,3 +1,6 @@
+# Metadata for the backstage catalog accessible at this link:
+# https://backstage.cdssandbox.xyz/
+---
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     github.com/project-slug: cds-snc/notification-go-client
 spec:
-  type: website
+  type: library
   owner: group:cds-snc/notify-dev
+  system: gc-notification
   lifecycle: experimental


### PR DESCRIPTION
# Summary | Résumé

Small fix to have the component listed as library (a go client) vs a website.

The impact is that we offer different views in the catalog based on the type of components. e.g. a Go client wouldn't have a user interface like a website or an api network like a service so we wouldn't display the API tab for example

An example of a website component:

![image](https://github.com/cds-snc/notification-go-client/assets/1690085/f08d6dc6-543a-4ef0-8337-8625dc1783d9)

An example of a service component:

![image](https://github.com/cds-snc/notification-go-client/assets/1690085/082a8001-b971-4cba-9477-0ae1fbcff81d)
 